### PR TITLE
Added "params" parameter while listing users in list_users() method

### DIFF
--- a/defectdojo_api/defectdojo.py
+++ b/defectdojo_api/defectdojo.py
@@ -110,7 +110,7 @@ class DefectDojoAPI(object):
         if username:
             params['username'] = username
 
-        return self._request('GET', 'users/')
+        return self._request('GET', 'users/', params)
 
     def get_user(self, user_id):
         """Retrieves a user using the given user id.


### PR DESCRIPTION
Please review the changes I have made. The underlying request method accepts the parameter "params". If the params field is left blank then it still performs the request same as before. 