### PR TITLE
Add time to CI/CD Text

### DIFF
--- a/examples/dojo_ci_cd.py
+++ b/examples/dojo_ci_cd.py
@@ -62,7 +62,8 @@ def return_engagement(dd, product_id, user, build_id=None):
     if users.success:
         user_id = users.data["objects"][0]["id"]
 
-    engagementText = "CI/CD Integration"
+    dojoTime = start_date.strftime("%H:%M:%S")
+    engagementText = "CI/CD Integration (" + dojoTime + ")"
     if build_id is not None:
         engagementText = engagementText + " - Build #" + build_id
 


### PR DESCRIPTION
As DefectDojo has the shortcomming of only showing date without time, time is added to the title.
To also add Y/M/D is not sufficent, as it will result in to much text for the title which means I would need to hover to see the exact time.